### PR TITLE
use grep -q to play nice with bioconda docker build

### DIFF
--- a/bin/legsta
+++ b/bin/legsta
@@ -33,7 +33,7 @@ $OUTSEP = ',' if $csv;  # default is tab
 $ENV{PATH} = $ENV{PATH}.":$FindBin::RealBin";
 require_exe('any2fasta');
 require_exe($ISPCR);
-system("$ISPCR 2>&1 | grep --silent minPerfect")==0 or err("Can not run $ISPCR");
+system("$ISPCR 2>&1 | grep -q minPerfect")==0 or err("Can not run $ISPCR");
 my $primer_fn = "$datadir/ispcr.tab";
 -r $primer_fn or err("Could not read file: $primer_fn");
 


### PR DESCRIPTION
Super minor PR. 

Bioconda uses Busy Box for the Docker containers, and the grep version included does not have `--silent` available.  This PR just makes use of the shorthand `-q` instead.